### PR TITLE
[dagster u] bump dagster to 1.6.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="dagster_university",
     packages=find_packages(exclude=["dagster_university_tests"]),
     install_requires=[
-        "dagster==1.5.*",
+        "dagster==1.6.*",
         "dagster-cloud",
         "dagster-duckdb",
         "geopandas",


### PR DESCRIPTION
In preparation for updating learning material to use features from 1.6, bump the required version of Dagster in `project-dagster-university`
