### PR TITLE
Update to use Dagster v1.6 Features: MaterializeResult

### DIFF
--- a/dagster_university/assets/metrics.py
+++ b/dagster_university/assets/metrics.py
@@ -1,4 +1,4 @@
-from dagster import asset, AssetKey, MetadataValue
+from dagster import asset, AssetKey, MetadataValue, MaterializeResult
 from dagster_duckdb import DuckDBResource
 
 import plotly.express as px
@@ -97,7 +97,7 @@ def manhattan_stats(database: DuckDBResource):
     deps=[AssetKey(["manhattan", "manhattan_stats"])],
     compute_kind="Python",
 )
-def manhattan_map(context):
+def manhattan_map():
     """
         A map of the number of trips per taxi zone in Manhattan
     """
@@ -124,7 +124,9 @@ def manhattan_map(context):
     # Convert the image data to base64
     base64_data = base64.b64encode(image_data).decode('utf-8')
     md_content = f"![Image](data:image/jpeg;base64,{base64_data})"
-    
-    context.add_output_metadata({
-        "preview": MetadataValue.md(md_content)
-    })
+
+    return MaterializeResult(
+        metadata={
+            "preview": MetadataValue.md(md_content)
+        }
+    )

--- a/dagster_university/assets/requests.py
+++ b/dagster_university/assets/requests.py
@@ -1,4 +1,4 @@
-from dagster import Config, asset, MetadataValue, get_dagster_logger
+from dagster import Config, asset, MaterializeResult, MetadataValue, get_dagster_logger
 from dagster_duckdb import DuckDBResource
 
 import plotly.express as px
@@ -18,7 +18,7 @@ class AdhocRequestConfig(Config):
     deps=["taxi_trips", "taxi_zones"],
     compute_kind="Python",
 )
-def adhoc_request(context, config: AdhocRequestConfig, database: DuckDBResource):
+def adhoc_request(config: AdhocRequestConfig, database: DuckDBResource):
     """
         The response to an request made in the `requests` directory.
         See `requests/README.md` for more information.
@@ -79,7 +79,9 @@ def adhoc_request(context, config: AdhocRequestConfig, database: DuckDBResource)
 
     base64_data = base64.b64encode(image_data).decode('utf-8')
     md_content = f"![Image](data:image/jpeg;base64,{base64_data})"
-    
-    context.add_output_metadata({
-        "preview": MetadataValue.md(md_content)
-    })
+
+    return MaterializeResult(
+        metadata={
+            "preview": MetadataValue.md(md_content)
+        }
+    )

--- a/dagster_university/assets/trips.py
+++ b/dagster_university/assets/trips.py
@@ -1,4 +1,4 @@
-from dagster import asset, MetadataValue
+from dagster import asset, MaterializeResult, MetadataValue
 from dagster_duckdb import DuckDBResource
 import pandas as pd 
 import requests
@@ -12,7 +12,7 @@ from ..partitions import monthly_partition
     group_name="raw_files",
     compute_kind="Python",
 )
-def taxi_zones_file(context):
+def taxi_zones_file():
     """
         The raw CSV file for the taxi zones dataset. Sourced from the NYC Open Data portal.
     """
@@ -23,7 +23,12 @@ def taxi_zones_file(context):
     with open(constants.TAXI_ZONES_FILE_PATH, "wb") as output_file:
         output_file.write(raw_taxi_zones.content)
     num_rows = len(pd.read_csv(constants.TAXI_ZONES_FILE_PATH))
-    context.add_output_metadata({'Number of records': MetadataValue.int(num_rows)})
+
+    return MaterializeResult(
+        metadata={
+            'Number of records': MetadataValue.int(num_rows)
+        }
+    )
     
 
 ## Lesson 4 (HW) , 6
@@ -72,7 +77,12 @@ def taxi_trips_file(context):
     with open(constants.TAXI_TRIPS_TEMPLATE_FILE_PATH.format(month_to_fetch), "wb") as output_file:
         output_file.write(raw_trips.content)
     num_rows = len(pd.read_parquet(constants.TAXI_TRIPS_TEMPLATE_FILE_PATH.format(month_to_fetch)))
-    context.add_output_metadata({'Number of records':MetadataValue.int(num_rows)})
+
+    return MaterializeResult(
+        metadata={
+            'Number of records': MetadataValue.int(num_rows)
+        }
+    )
 
 
 ## Lesson 4, 8, 6


### PR DESCRIPTION
Depends on - https://github.com/dagster-io/project-dagster-university/pull/6

---

## Changes

- replaces `context.add_output_metadata` with `MaterializeResult(metadata=...)`