### PR TITLE
Added missing dependency for metadata lesson

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
         "pandas",
         "plotly",
         "shapely",
+        "pyarrow",
     ],
     extras_require={"dev": ["dagster-webserver", "pytest"]},
 )


### PR DESCRIPTION
This dependency is required to use the Pandas method _read_parquet_ in the _metadata_ section. [Link](https://github.com/dagster-io/dagster/blob/ee5acad7526bf86fdf4c11d15e8332985973cde1/docs/dagster-university/pages/dagster-essentials/extra-credit/materialization-metadata.md?plain=1#L55)

Without this dependency, you will receive errors when materializing the _taxi_trip_file_