### PR TITLE
Remove duplicate constants

### DIFF
--- a/dagster_university/assets/constants.py
+++ b/dagster_university/assets/constants.py
@@ -1,8 +1,5 @@
 import os
 
-TAXI_ZONES_FILE_PATH = "data/raw/taxi_zones.csv"
-TAXI_TRIPS_TEMPLATE_FILE_PATH = "data/raw/taxi_trips_{}.parquet"
-
 TAXI_ZONES_FILE_PATH = os.path.join("data", "raw", "taxi_zones.csv")
 TAXI_TRIPS_TEMPLATE_FILE_PATH = os.path.join("data", "raw", "taxi_trips_{}.parquet")
 


### PR DESCRIPTION
This PR removes duplicate constants from `assets/constants.py`. Opting to go for the `os.path` option to be consistent with how other variables are constructed.

Resolves [DEV-143](https://linear.app/dagster-labs/issue/DEV-143/[daggy-u]-[essentials]-duplicate-consts-found-in-constantspy-file).