### PR TITLE
Update dagster to 1.6.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="dagster_university",
     packages=find_packages(exclude=["dagster_university_tests"]),
     install_requires=[
-        "dagster==1.5.*",
+        "dagster==1.6.*",
         "dagster-cloud",
         "dagster-duckdb",
         "dagster-dbt",


### PR DESCRIPTION
This PR updates the required Dagster version for the `module/dagster-and-dbt` branch to `1.6.*` in `setup.py`.

Feel free to ❌ it if it's not ready for this!