### PR TITLE
Update Dagster version in setup.py for dbt starter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="dagster_university",
     packages=find_packages(exclude=["dagster_university_tests"]),
     install_requires=[
-        "dagster==1.5.*",
+        "dagster==1.6.*",
         "dagster-cloud",
         "dagster-duckdb",
         "dagster-dbt",


### PR DESCRIPTION
This updates the Dagster version in `setup.py` to `1.6.*` for the dbt starter project.