### PR TITLE
[module/dagster-and-dbt-starter] add pyarrow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "s3fs",
         "smart_open",
         "boto3",
+        "pyarrow",
     ],
     extras_require={"dev": ["dagster-webserver", "pytest"]},
 )


### PR DESCRIPTION
- required by pandas when reading duckdb

linked: https://github.com/dagster-io/project-dagster-university/pull/21
linked: https://github.com/dagster-io/dagster/pull/21421