### PR TITLE
[module/dagster-and-dbt] remove strptime for incremental model

### DIFF
--- a/analytics/models/marts/daily_metrics.sql
+++ b/analytics/models/marts/daily_metrics.sql
@@ -25,5 +25,5 @@ with
 select *
 from daily_summary
 {% if is_incremental() %}
-    where date_of_business >= strptime('{{ var('min_date') }}', '%c') and date_of_business < strptime('{{ var('max_date') }}', '%c')
+    where date_of_business >= '{{ var('min_date') }}' and date_of_business < '{{ var('max_date') }}'
 {% endif %}

--- a/analytics/models/marts/daily_metrics.sql
+++ b/analytics/models/marts/daily_metrics.sql
@@ -25,5 +25,5 @@ with
 select *
 from daily_summary
 {% if is_incremental() %}
-    where date_of_business >= '{{ var('min_date') }}' and date_of_business < '{{ var('max_date') }}'
+    where date_of_business between '{{ var('min_date') }}' and '{{ var('max_date') }}'
 {% endif %}

--- a/dagster_university/assets/dbt.py
+++ b/dagster_university/assets/dbt.py
@@ -74,8 +74,8 @@ def incremental_dbt_models(
     time_window = context.partition_time_window
 
     dbt_vars = {
-        "min_date": time_window.start.isoformat(),
-        "max_date": time_window.end.isoformat()
+        "min_date": time_window.start.strftime('%Y-%m-%d'),
+        "max_date": time_window.end.strftime('%Y-%m-%d')
     }
     
     yield from dbt.cli(["build", "--vars", json.dumps(dbt_vars)], context=context).stream()


### PR DESCRIPTION
```python
>>> pendulum.now().isoformat()
'2024-04-25T11:45:47.749103-04:00'
```
```sql
D select strptime('2024-04-25T11:29:18.217685', '%c');
Invalid Input Error: Could not parse string "2024-04-25T11:29:18.217685" according to format specifier "%c"
2024-04-25T11:29:18.217685
          ^
Error: Space does not match, expected
```
The `%c` format does not correctly parse pendulum date times.
https://duckdb.org/docs/sql/functions/dateformat.html

Corresponding change in main repo:
https://github.com/dagster-io/dagster/pull/21425#pullrequestreview-2023096152
