### PR TITLE
[dagster-and-dbt] rm fastparquet dependency as unnecessary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         "smart_open",
         "boto3",
         "pyarrow",
-        "fastparquet",
     ],
     extras_require={"dev": ["dagster-webserver", "pytest"]},
 )


### PR DESCRIPTION
- removes `fastparquet` dependency as unnecessary

## Testing

Confirmed materialization was successful for all assets after creating a new venv and re-installing dependencies.
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/b0761086-8ca4-4649-b966-a3cf45b0237f">
