### PR TITLE
RunRequest missing dg

### DIFF
--- a/course/pages/dagster-essentials/lesson-9/building-the-sensor.md
+++ b/course/pages/dagster-essentials/lesson-9/building-the-sensor.md
@@ -114,7 +114,7 @@ Now that cursors have been explained, let’s start writing the sensor.
                with open(file_path, "r") as f:
                    request_config = json.load(f)
 
-                   runs_to_request.append(RunRequest(
+                   runs_to_request.append(dg.RunRequest(
                        run_key=f"adhoc_request_{filename}_{last_modified}",
                        run_config={
                            "ops": {
@@ -178,7 +178,7 @@ def adhoc_request_sensor(context: dg.SensorEvaluationContext):
                 with open(file_path, "r") as f:
                     request_config = json.load(f)
 
-                    runs_to_request.append(RunRequest(
+                    runs_to_request.append(dg.RunRequest(
                         run_key=f"adhoc_request_{filename}_{last_modified}",
                         run_config={
                             "ops": {


### PR DESCRIPTION
Instructions in Dagster Essentials - Lesson 9 uses `import dagster as dg` but `RunRequests` is missing `dg`.