### PR TITLE
hide .tmp_dagster_home*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,7 @@ cython_debug/
 #.idea/
 
 tmp*/
+.tmp*
 
 *.duckdb
 *.geojson


### PR DESCRIPTION
I noticed while going through the `dagster_essentials` course that `.tmp_dagster_home_*` directories were not ignored by **git**. So I'm proposing to add it to `.gitignore`.

Yes, I'm being optimistic here and ignoring all `.tmp*` files/directories, as the previous line does to `tmp*` files/directories. Feel free to make it more targeted.