### PR TITLE
Testing course: Consistency fixes

### DIFF
--- a/course/pages/dagster-testing/lesson-3/1-unit-tests.md
+++ b/course/pages/dagster-testing/lesson-3/1-unit-tests.md
@@ -94,7 +94,7 @@ If you are familiar with Python testing, writing a test for an asset should look
 To run this test, use the pytest CLI from the virtual environment:
 
 ```bash
-> pytest dagster_testing_tests/test_lesson_3.py::test_total_population
+> pytest dagster_testing_tests/test_lesson_3.py::test_state_population_file
 ...
 dagster_testing_tests/test_lesson_3.py .                                                          [100%]
 ```

--- a/course/pages/dagster-testing/lesson-3/2-testing-dependencies.md
+++ b/course/pages/dagster-testing/lesson-3/2-testing-dependencies.md
@@ -58,7 +58,7 @@ dagster_testing_tests/test_lesson_3.py .                                        
 
 As your pipelines become more complex, it's a good idea to test materializing your Dagster assets. `dg.materialize()` is a `dagster.ExecuteInProcessResult` which will execute assets. We can then check the `success` property of the execution to ensure that everything materialized as expected.
 
-Since the `processed_file` asset only relies on the output of  the `loaded_file` asset, we can materialize both of those assets together to ensure they are working as expected:
+Since the `total_population` asset only relies on the output of  the `state_population_file` asset, we can materialize both of those assets together to ensure they are working as expected:
 
 ```python
 def test_assets():

--- a/course/pages/dagster-testing/lesson-4/3-materializing-resource-tests.md
+++ b/course/pages/dagster-testing/lesson-4/3-materializing-resource-tests.md
@@ -9,7 +9,7 @@ lesson: '4'
 When we discussed unit tests we showed how you can execute one or more assets together using `dg.materialize()`. We can still materialize our assets this way using mocks.
 
 ```python
-# /dagster_testing/assets/lesson_4.py
+# /dagster_testing_tests/test_lesson_4.py
 @patch("requests.get")
 def test_state_population_api_assets(mock_get, example_response, api_output):
     mock_response = Mock()
@@ -41,7 +41,7 @@ This uses the same patch and mocked object as before. The only difference is tha
 
 ## Testing with materialize and config
 
-We can also materialize resources and configs together. We will make a slight modification to our `author_works_with_resource` so it can take in a run configuration.
+We can also materialize resources and configs together. We will make a slight modification to our `state_population_api_resource_config` so it can take in a run configuration.
 
 ```python
 class StateConfig(dg.Config):


### PR DESCRIPTION
This PRs fixes a few internal consistency errors in the text of the Testing with Dagster course.

Since it's only a few minor points in the text, I have not created a corresponding issue - please let me know if I should do so.