### PR TITLE
Correct Essentials file path

### DIFF
--- a/course/pages/dagster-essentials/lesson-3/2-defining-your-first-asset.md
+++ b/course/pages/dagster-essentials/lesson-3/2-defining-your-first-asset.md
@@ -16,6 +16,8 @@ Before we write our first asset, let's talk a little about project structures in
 
 However we can use `dg` to scaffold a file for our first asset. Run the following command to create the file that will contain our first asset.
 
+ **Note:** `dg` commands need to be run within the Dagster project specific for the course (In this case in `dagster_university/dagster_essentials`). Though the `dg` command can be executed from anywhere within the project.
+
 ```bash
 dg scaffold defs dagster.asset assets/trips.py
 ```

--- a/course/pages/dagster-essentials/lesson-5/1-whats-the-definitions-object.md
+++ b/course/pages/dagster-essentials/lesson-5/1-whats-the-definitions-object.md
@@ -59,7 +59,7 @@ registry_modules = [
 ]
 ```
 
-In your project, open the `dagster_university/dagster_essentials/src/definitions.py` file. It should look like the following code:
+In your project, open the `dagster_university/dagster_essentials/src/dagster_essentials/definitions.py` file. It should look like the following code:
 
 ```python
 from pathlib import Path


### PR DESCRIPTION
Correct Dagster Essentials file path in `definitions` section and add clarification on executing `dg` commands.