### PR TITLE
Fix dynamic partition handling in lesson 3

### DIFF
--- a/course/pages/dagster-etl/lesson-3/4-complex-partitions.md
+++ b/course/pages/dagster-etl/lesson-3/4-complex-partitions.md
@@ -69,7 +69,7 @@ def duckdb_dynamic_partition_table(
         conn.execute(
             f"delete from {table_name} where date = '{context.partition_key}';"
         )
-        conn.execute(f"copy {table_name} from '{import_dynamic_partition_file}'")
+        conn.execute(f"copy {table_name} from '{import_dynamic_partition_file}';")
 ```
 
 This setup should look very similar to the daily partition we created earlier. But how does it play out in practice? To better understand the distinction, let’s dive into the differences in how partitioned pipelines are triggered. Each type requires a different approach to scheduling and orchestration, depending on how and when new data becomes available.

--- a/course/pages/dagster-etl/lesson-3/5-triggering-partitions.md
+++ b/course/pages/dagster-etl/lesson-3/5-triggering-partitions.md
@@ -56,7 +56,7 @@ from pathlib import Path
 import dagster as dg
 
 import dagster_and_etl.defs.jobs as jobs
-
+from dagster_and_etl.defs.assets import dynamic_partitions_def
 
 @dg.sensor(target=jobs.import_dynamic_partition_job)
 def dynamic_sensor(context: dg.SensorEvaluationContext):
@@ -65,20 +65,28 @@ def dynamic_sensor(context: dg.SensorEvaluationContext):
     previous_state = json.loads(context.cursor) if context.cursor else {}
     current_state = {}
     runs_to_request = []
+    dynamic_partitions_requests = []
 
     for filename in os.listdir(file_path):
         if filename not in previous_state:
+            partition_key = filename.split(".")[0]
             last_modified = os.path.getmtime(file_path)
             current_state[filename] = last_modified
 
+            dynamic_partitions_requests.append(partition_key)
             runs_to_request.append(
                 dg.RunRequest(
                     run_key=filename,
+                    partition_key=partition_key,
                 )
             )
 
     return dg.SensorResult(
-        run_requests=runs_to_request, cursor=json.dumps(current_state)
+        run_requests=runs_to_request,
+        cursor=json.dumps(current_state),
+        dynamic_partitions_requests=[
+            dynamic_partitions_def.build_add_request(dynamic_partitions_requests)
+        ],
     )
 ```
 

--- a/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_3/defs/assets.py
+++ b/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_3/defs/assets.py
@@ -166,9 +166,7 @@ def duckdb_dynamic_partition_table(
         conn.execute(
             f"delete from {table_name} where date = '{context.partition_key}';"
         )
-        conn.execute(
-            f"copy {table_name} from '{import_dynamic_partition_file[context.partition_key]}'"
-        )
+        conn.execute(f"copy {table_name} from '{import_dynamic_partition_file}';")
 
 
 # Example 4 - Cloud Storage

--- a/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_3/defs/assets.py
+++ b/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_3/defs/assets.py
@@ -166,7 +166,9 @@ def duckdb_dynamic_partition_table(
         conn.execute(
             f"delete from {table_name} where date = '{context.partition_key}';"
         )
-        conn.execute(f"copy {table_name} from '{import_dynamic_partition_file}'")
+        conn.execute(
+            f"copy {table_name} from '{import_dynamic_partition_file[context.partition_key]}'"
+        )
 
 
 # Example 4 - Cloud Storage

--- a/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_3/defs/sensors.py
+++ b/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_3/defs/sensors.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import dagster as dg
 
 import dagster_and_etl.completed.lesson_3.defs.jobs as jobs
+from dagster_and_etl.completed.lesson_3.defs.assets import dynamic_partitions_def
 
 
 @dg.sensor(target=jobs.import_dynamic_partition_job)
@@ -14,18 +15,26 @@ def dynamic_sensor(context: dg.SensorEvaluationContext):
     previous_state = json.loads(context.cursor) if context.cursor else {}
     current_state = {}
     runs_to_request = []
+    dynamic_partitions_requests = []
 
     for filename in os.listdir(file_path):
         if filename not in previous_state:
+            partition_key = filename.split(".")[0]
             last_modified = os.path.getmtime(file_path)
             current_state[filename] = last_modified
 
+            dynamic_partitions_requests.append(partition_key)
             runs_to_request.append(
                 dg.RunRequest(
                     run_key=filename,
+                    partition_key=partition_key,
                 )
             )
 
     return dg.SensorResult(
-        run_requests=runs_to_request, cursor=json.dumps(current_state)
+        run_requests=runs_to_request,
+        cursor=json.dumps(current_state),
+        dynamic_partitions_requests=[
+            dynamic_partitions_def.build_add_request(dynamic_partitions_requests)
+        ],
     )


### PR DESCRIPTION
### 🛠 Fix: Missing Partition Key Error in Dynamic Partition Sensor (*Dagster & ETL* Lesson 3)

This PR addresses an issue in **Lesson 3: Triggering Partitions** of the *Dagster & ETL* course where sensor runs fail due to a missing partition key.

---

### ✅ Changes Made

* **`duckdb_dynamic_partition_table`**
  Updated to correctly reference and use the dynamic partition key for file-based imports.

* **`dynamic_sensor`**
  Modified to construct run requests that include the appropriate partition keys for dynamic partitions.

---

### 🧪 Result

Sensor executions now succeed without partition key errors, enabling correct triggering of runs tied to dynamic partitions.
