### PR TITLE
`dg` Install instructions

### DIFF
--- a/course/pages/installation/set-up-local.md
+++ b/course/pages/installation/set-up-local.md
@@ -5,7 +5,7 @@ lesson: '2'
 
 # Set up local
 
-This will set up Dagster for you local machine. If you would prefer to do this course in Github Codespaces, please follow [that guide](/dagster-essentials/lesson-2/2-set-up-codespace).
+This will set up Dagster for you local machine. If you would prefer to do this course in Github Codespaces, please follow [that guide](/installation/set-up-codespace).
 
 - **To install git.** Refer to the [Git documentation](https://github.com/git-guides/install-git) if you don’t have this installed.
 - **To have Python installed.**  Dagster supports Python 3.9 - 3.12 (3.12 recommended).
@@ -30,21 +30,17 @@ For example, if you are completing "Dagster Essentials", change into that direct
 cd dagster_university/dagster_essentials
 ```
 
-## Install uv and dg
+## Install the dependencies
 
-Now we want to install `dg`. This is the command line interface that makes it easy to interact with Dagster. Throughout the course we will use `dg` to scaffold our project and streamline the development process.
+**uv**
 
-In order to best use `dg` we will need the Python package manager [`uv`](https://docs.astral.sh/uv/). `uv` will allow us to install `dg` globally and more easily build our virtual environments.
-
-If you do not have `uv` instead already, you can do so with:
+If you do not have [`uv`](https://docs.astral.sh/uv/) installed, you can do so with:
 
 ```bash
 brew install uv
 ```
 
-## Install the dependencies
-
-To install the python dependencies with [uv](https://docs.astral.sh/uv/). While in the course specific directory run the following:
+To install the python dependencies with `uv`. While in the course specific directory run the following:
 
 ```bash
 uv sync


### PR DESCRIPTION
The installation instructions were unclear since they still used a lot of language of when `dg` and `uv` were much more coupled.