### PR TITLE
Fix ETL sling jobs

### DIFF
--- a/course/pages/dagster-etl/lesson-6/5-managing-sling-assets.md
+++ b/course/pages/dagster-etl/lesson-6/5-managing-sling-assets.md
@@ -30,6 +30,8 @@ postgres_refresh_job = dg.define_asset_job(
     "postgres_refresh",
     selection=[
         dg.AssetKey(["target", "data", "customers"]),
+        dg.AssetKey(["target", "data", "products"]),
+        dg.AssetKey(["target", "data", "orders"]),
     ],
 )
 

--- a/course/pages/dagster-etl/lesson-6/5-managing-sling-assets.md
+++ b/course/pages/dagster-etl/lesson-6/5-managing-sling-assets.md
@@ -27,10 +27,18 @@ We’d define two separate jobs:
 import dagster as dg
 
 postgres_refresh_job = dg.define_asset_job(
-    "postgres_refresh", selection=["customers", "products", "orders"]
+    "postgres_refresh",
+    selection=[
+        dg.AssetKey(["target", "data", "customers"]),
+    ],
 )
 
-orders_refresh_job = dg.define_asset_job("orders_refresh", selection=["orders"])
+orders_refresh_job = dg.define_asset_job(
+    "orders_refresh",
+    selection=[
+        dg.AssetKey(["target", "data", "orders"]),
+    ],
+)
 ```
 
 Then we can create two distinct schedules with different cron expressions:

--- a/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_6/defs/jobs.py
+++ b/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_6/defs/jobs.py
@@ -1,7 +1,15 @@
 import dagster as dg
 
 postgres_refresh_job = dg.define_asset_job(
-    "postgres_refresh", selection=["customers", "products", "orders"]
+    "postgres_refresh",
+    selection=[
+        dg.AssetKey(["target", "data", "customers"]),
+    ],
 )
 
-orders_refresh_job = dg.define_asset_job("orders_refresh", selection=["orders"])
+orders_refresh_job = dg.define_asset_job(
+    "orders_refresh",
+    selection=[
+        dg.AssetKey(["target", "data", "orders"]),
+    ],
+)

--- a/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_6/defs/jobs.py
+++ b/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_6/defs/jobs.py
@@ -4,6 +4,8 @@ postgres_refresh_job = dg.define_asset_job(
     "postgres_refresh",
     selection=[
         dg.AssetKey(["target", "data", "customers"]),
+        dg.AssetKey(["target", "data", "products"]),
+        dg.AssetKey(["target", "data", "orders"]),
     ],
 )
 

--- a/dagster_university/dagster_and_etl/tests/test_lesson_6.py
+++ b/dagster_university/dagster_and_etl/tests/test_lesson_6.py
@@ -5,6 +5,13 @@ import dagster_and_etl.completed.lesson_6.defs
 from tests.fixtures import docker_compose  # noqa: F401
 
 
+@pytest.fixture()
+def defs():
+    return dg.Definitions.merge(
+        dg.components.load_defs(dagster_and_etl.completed.lesson_6.defs)
+    )
+
+
 @pytest.mark.integration
 def test_sling_replication_config(docker_compose):  # noqa: F811
     import yaml
@@ -68,7 +75,23 @@ def test_incremental_replication(docker_compose):  # noqa: F811
 
 
 @pytest.mark.integration
-def test_defs():
-    assert dg.Definitions.merge(
-        dg.components.load_defs(dagster_and_etl.completed.lesson_6.defs)
-    )
+def test_job_postgres_refresh(defs, docker_compose):  # noqa: F811
+    import dagster_and_etl.completed.lesson_6.defs.assets as assets
+    from dagster_and_etl.completed.lesson_6.defs.resources import sling
+
+    my_job = defs.get_job_def("postgres_refresh")
+    my_job.execute_in_process()
+
+
+@pytest.mark.integration
+def test_job_orders_refresh(defs, docker_compose):  # noqa: F811
+    import dagster_and_etl.completed.lesson_6.defs.assets as assets
+    from dagster_and_etl.completed.lesson_6.defs.resources import sling
+
+    my_job = defs.get_job_def("orders_refresh")
+    my_job.execute_in_process()
+
+
+@pytest.mark.integration
+def test_defs(defs):
+    assert defs


### PR DESCRIPTION
The jobs used in the sling section of the ETL course needed qualified asset keys. Also including tests.

https://github.com/dagster-io/project-dagster-university/issues/126