### PR TITLE
Remove sub module grouping

### DIFF
--- a/course/pages/dagster-essentials/extra-credit/4-coding-practice-grouping-assets.md
+++ b/course/pages/dagster-essentials/extra-credit/4-coding-practice-grouping-assets.md
@@ -30,21 +30,6 @@ For the assets in the `raw_files` and `ingested` groups, your assets should look
 def name_of_asset():
 ```
 
-### For the asset submodule method:
-
-You can create a new file in the `defs` directory called `groups.py` and import the assets in the `requests` module, and apply a group using the `load_assets_from_modules`:
-
-```python {% obfuscated="true" %}
-import dagster as dg
-
-from dagster_essentials.defs.assets import requests
-
-request_assets = dg.load_assets_from_modules(
-    modules=[requests],
-    group_name="requests",
-)
-```
-
 ### The Dagster UI:
 
 After adding the assets to the groups, the asset graph should look like this:

--- a/dagster_university/dagster_essentials/src/dagster_essentials/completed/lesson_9/defs/groups.py
+++ b/dagster_university/dagster_essentials/src/dagster_essentials/completed/lesson_9/defs/groups.py
@@ -1,8 +1,0 @@
-import dagster as dg
-
-from dagster_essentials.completed.lesson_9.defs.assets import requests
-
-request_assets = dg.load_assets_from_modules(
-    modules=[requests],
-    group_name="requests",
-)


### PR DESCRIPTION
Removing the sub module section from the extra credit. There really isn't a great way to do this with the new `dg` structure without putting things in sub directories which is a bigger change to the course

https://docs.dagster.io/guides/build/assets/metadata-and-tags/adding-attributes-to-assets