### PR TITLE
Refactor pyproject.toml files to use [dependency-groups] for dev dependencies

### DIFF
--- a/dagster_university/dagster_and_dbt/pyproject.toml
+++ b/dagster_university/dagster_and_dbt/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
     "pyproj>=3.7.0",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
 ]

--- a/dagster_university/dagster_and_etl/pyproject.toml
+++ b/dagster_university/dagster_and_etl/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
     "pandas",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
 ]

--- a/dagster_university/dagster_essentials/pyproject.toml
+++ b/dagster_university/dagster_essentials/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
     "pyproj>=3.7.0",
 ]
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "ruff",
     "pytest",
 ]

--- a/dagster_university/dagster_testing/pyproject.toml
+++ b/dagster_university/dagster_testing/pyproject.toml
@@ -13,9 +13,9 @@ dependencies = [
     "pytest",
 ]
 
-[tool.uv]
-dev-dependencies = [
-    "ruff",
+[dependency-groups]
+dev = [
+    "ruff"
 ]
 
 [build-system]


### PR DESCRIPTION
- **What**: Replace the deprecated `tool.uv.dev-dependencies` field with `dependency-groups.dev` in `pyproject.toml`
- **Why**: uv sync warns that `tool.uv.dev-dependencies` is deprecated and will be removed; switching to `dependency-groups.dev` removes the warning and future-proofs test dependency handling.