### PR TITLE
Fix linkcheck

### DIFF
--- a/course/.markdown-link-check.json
+++ b/course/.markdown-link-check.json
@@ -5,7 +5,9 @@
     { "pattern": "^http://localhost:3000" },
     { "pattern": "^https://courses\\.dagster\\.io" },
     { "pattern": "^https://duckdb\\.org" },
-    { "pattern": "^https://openai\\.com" }
+    { "pattern": "^https://openai\\.com" },
+    { "pattern": "^https://dagster\\.io/slack" },
+    { "pattern": "^https://join\\.slack\\.com" }
   ],
   "timeout": "10s",
   "retryOn429": true,


### PR DESCRIPTION
Add patterns: `dagster.io/slack` and `join.slack.com` to be ignored by `yarn lintcheck`