### PR TITLE
ETL course feedback

### DIFF
--- a/course/pages/dagster-etl/lesson-5/4-refactoring-static-data-with-dlt.md
+++ b/course/pages/dagster-etl/lesson-5/4-refactoring-static-data-with-dlt.md
@@ -24,20 +24,20 @@ def import_file(context: dg.AssetExecutionContext, config: FilePath) -> str:
     return str(file_path.resolve())
 ```
 
-Next, we need to define the `dlt.source` function for our CSV pipeline. This will look very similar to the `simple_source` function we used earlier, but with a few changes: it will read from a CSV file and take a file path as an input parameter. This allows us to dynamically pass in the file we want to process, while letting dlt handle the parsing and schema inference:
+Next, we need to define the `dlt.source` function for our CSV pipeline. This will look very similar to the `simple_source` function we used earlier, but with a few changes: it will read from a CSV file and take a file path as an input parameter. This allows us to dynamically pass in the file we want to process, while letting dlt handle schema inference:
 
 ```python {% obfuscated="true" %}
 @dlt.source
 def csv_source(file_path: str = None):
     def load_csv():
-        with open(file_path, mode="r", encoding="utf-8") as file:
-            reader = csv.DictReader(file)
-            data = [row for row in reader]
-
-        yield data
+        import pandas as pd
+        df = pd.read_csv(file_path)
+        yield df.to_dict(orient="records")
 
     return load_csv
 ```
+
+Using `pandas.read_csv()` here is important: unlike Python's built-in `csv.DictReader`, pandas infers column types from the data, giving dlt the typed values it needs to write the correct schema to DuckDB.
 
 This is very helpful. Before our pipelines had to be hardcoded to define the schema for the destination table. Offloading your schema management to a framework can make your pipelines much less error prone. Though it is still good to be aware of what data types it has selected. Just because a zip code looks like an integer does not mean that is how we want the data represented.
 

--- a/course/pages/dagster-etl/lesson-6/3-sling-database-replication-set-up.md
+++ b/course/pages/dagster-etl/lesson-6/3-sling-database-replication-set-up.md
@@ -13,7 +13,7 @@ One of the easiest ways to spin up a temporary database is with [Docker](https:/
 To get started, run the following command:
 
 ```bash
-docker compose -f dagster_and_etl_tests/docker-compose.yaml up -d
+docker compose -f tests/docker-compose.yaml up -d
 ```
 
 **Note:** The first time you run this command, Docker may need to download the required image, so it could take a few minutes.

--- a/course/pages/dagster-etl/lesson-6/4-dagster-and-sling.md
+++ b/course/pages/dagster-etl/lesson-6/4-dagster-and-sling.md
@@ -41,6 +41,18 @@ With the source and destination defined, we can combine them together in the `Sl
 
 ```python
 # src/dagster_and_etl/defs/resources.py
+sling = SlingResource(
+    connections=[
+        source,
+        destination,
+    ]
+)
+```
+
+Finally, expose `sling` through the `Definitions` object:
+
+```python
+# src/dagster_and_etl/defs/resources.py
 @dg.definitions
 def resources():
     return dg.Definitions(

--- a/course/pages/dagster-etl/lesson-7/4-organizing-our-project.md
+++ b/course/pages/dagster-etl/lesson-7/4-organizing-our-project.md
@@ -9,3 +9,28 @@ lesson: '7'
 Organizing your Dagster project with components brings structure, scalability, and clarity to your data platform. Instead of building one large codebase where assets, resources, and configurations are tightly coupled, components allow you to break your project into self-contained modules. Each component bundles together related logic—such as a data source, transformation, or model training step—along with its resources and config schemas. This modular layout makes it easier to onboard new team members, reuse functionality across pipelines, and iterate on parts of your system without risking unrelated functionality.
 
 A well-organized component-based project typically follows a pattern where each component lives in its own directory or package, complete with its own virtual environment, tests, and documentation. For example, you might have components/snowflake_ingestion, components/ml_training, and components/reporting_pipeline, each representing a logical slice of your platform. This structure encourages encapsulation and reduces dependency sprawl, allowing individual components to evolve at their own pace. By centralizing composition in your definitions.py file (or similar), you can declaratively stitch components together to build end-to-end workflows without compromising maintainability. As your team and projects grow, components provide the foundation for a scalable and collaborative development model.
+
+## Navigating a large asset graph
+
+As your project grows, the asset graph in the Dagster UI can become crowded. Asset groups and tags let you filter the graph without restructuring your code.
+
+**Asset groups** assign a set of assets to a named category, which appears as a filter in the UI. You can set a group on any asset with the `group_name` parameter:
+
+```python
+@dg.asset(group_name="ingestion")
+def raw_orders(): ...
+
+@dg.asset(group_name="transforms")
+def orders_by_customer(): ...
+```
+
+You can then click a group name in the asset graph to show only the assets in that group.
+
+**Tags** offer finer-grained filtering. Any key-value pair works:
+
+```python
+@dg.asset(tags={"layer": "staging", "source": "postgres"})
+def staging_orders(): ...
+```
+
+Use tags to filter by team, environment, data domain, or any dimension that makes sense for your project. Groups and tags compose: you can narrow the graph to a group and then filter further by tag.

--- a/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_5/defs/assets.py
+++ b/dagster_university/dagster_and_etl/src/dagster_and_etl/completed/lesson_5/defs/assets.py
@@ -1,10 +1,10 @@
-import csv
 import datetime
 import os
 from pathlib import Path
 
 import dagster as dg
 import dlt
+import pandas as pd
 import requests
 from dagster_dlt import DagsterDltResource, DagsterDltTranslator, dlt_assets
 from dagster_dlt.translator import DltResourceTranslatorData
@@ -53,11 +53,8 @@ def import_file(context: dg.AssetExecutionContext, config: FilePath) -> str:
 @dlt.source
 def csv_source(file_path: str = None):
     def load_csv():
-        with open(file_path, mode="r", encoding="utf-8") as file:
-            reader = csv.DictReader(file)
-            data = [row for row in reader]
-
-        yield data
+        df = pd.read_csv(file_path)
+        yield df.to_dict(orient="records")
 
     return load_csv
 


### PR DESCRIPTION
Addresses three bugs reported by a student and adds new content on asset graph navigation.

Bug fixes
- Fix incorrect docker-compose path in lesson 6 setup (dagster_and_etl_tests/... → tests/docker-compose.yaml)
- Add missing sling = SlingResource(connections=[source, destination]) code block in lesson 6 — the resources page referenced sling without ever defining it, leaving students to hunt for it in completed/
- Fix dlt CSV type inference: switch csv_source from csv.DictReader (yields all strings) to pandas.read_csv() (yields typed values), so dlt correctly infers column types. Update lesson 5 code block and add a one-sentence explanation of why pandas is needed

New content
- Add "Navigating a large asset graph" section to lesson 7 covering group_name and tags for filtering the Dagster UI asset graph without restructuring code